### PR TITLE
Removed `anyobject_protocol` rule.

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -9,7 +9,6 @@ excluded:
     - LocalPackages/*/DerivedData
 
 opt_in_rules:
-    - anyobject_protocol
     - array_init
     - contains_over_first_not_nil
     - convenience_type


### PR DESCRIPTION
This rule is deprecated now. (https://github.com/realm/SwiftLint/blob/main/CHANGELOG.md#)

<img width="954" alt="Screenshot 2023-08-16 at 16 01 57" src="https://github.com/cricut/swiftlint-config/assets/86780629/4ac52179-b92a-4154-9ed3-ecfebf35d735">
